### PR TITLE
fix: handle reasoning traces in LLM response callback

### DIFF
--- a/gptel-forge-prs.el
+++ b/gptel-forge-prs.el
@@ -201,8 +201,10 @@ BUFFER-TEMPLATE is existing buffer content to use as a template structure."
       :context nil
       :callback (lambda (response info)
                   (cond
-                   (response
+                   ((stringp response)
                     (funcall callback response))
+                   ((and (consp response) (eq (car response) 'reasoning))
+                    nil) ; silently ignore reasoning traces
                    ((plist-get info :error)
                     (message "gptel-forge-prs: Error: %s"
                              (or (plist-get (plist-get info :error) :message)


### PR DESCRIPTION
Models with extended thinking return reasoning traces as
(reasoning . text) cons cells. The prior (response ...) cond
branch matched any non-nil value, passing cons cells to callers
that call insert, causing char-or-string-p errors. Check stringp
first and silently ignore reasoning cons cells.